### PR TITLE
fix(markdown-previewer): correct paragraph count calculation to split by new lines

### DIFF
--- a/src/app/markdown-previewer/page.tsx
+++ b/src/app/markdown-previewer/page.tsx
@@ -25,7 +25,8 @@ function MarkdownPreviewer() {
   const words = value.match(/\S+/g)?.length || 0
   const chars = value.length || 0
   const charsWithoutSpaces = value.replaceAll(" ", "").length || 0
-  const paragraphs = value.split("\n\n").filter((paragraph) => paragraph.trim() !== "").length || 0
+  const paragraphs =
+    value.split('\n').filter((paragraph) => paragraph !== '').length || 0
 
   const parseMarkdown = (markdownText: string) => {
     const unorderedListProcessedText = parseUnorderedList(markdownText);


### PR DESCRIPTION
This pull request includes a change to the `MarkdownPreviewer` function in the `src/app/markdown-previewer/page.tsx` file. The change modifies the logic for counting paragraphs to improve accuracy.

* [`src/app/markdown-previewer/page.tsx`](diffhunk://#diff-ce009044942896000c74e68c838c354dc50986a2d9c7a5e4f322254827b0d97fL28-R29): Changed the paragraph counting logic to split the text by single newline characters instead of double newline characters.