### PR TITLE
feat: update hero section and fix footer image quality

### DIFF
--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -14,9 +14,8 @@ export default function Hero() {
         </div>
 
         <h1 className="text-balance text-4xl font-bold tracking-tight md:text-6xl">
-          The{" "}
-          <span className="bg-gradient-to-r from-orange-500 to-amber-500 bg-clip-text text-transparent">Awesome</span>{" "}
-          Online Tools
+          <span className="bg-gradient-to-r from-orange-500 to-amber-500 bg-clip-text text-transparent">Lin Hugo</span>{" "}
+          Tools
         </h1>
 
         <p className="mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground">
@@ -39,22 +38,7 @@ export default function Hero() {
           </Button>
         </div>
 
-        <p className="mt-8 text-sm text-muted-foreground">
-          Created by{" "}
-          <Link
-            href="https://1chooo.com"
-            className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
-          >
-            @1chooo
-          </Link>
-          , inspired by{" "}
-          <Link
-            href="https://honghong.me"
-            className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
-          >
-            @tszhong0411
-          </Link>
-        </p>
+
       </div>
     </section>
   )


### PR DESCRIPTION
This PR updates the hero section content and resolves a configuration error with the footer image quality.

**Problem/Issue/Goal:**
- The hero section heading was generic and included unnecessary attribution text
- The footer image component used an unconfigured quality setting, leading to potential build or runtime errors

**Fix/Solution:**
- Updated hero heading to "Lin Hugo Tools" and removed the "Created by" paragraph
- Removed the `quality={100}` prop from the footer Image component to use default settings

Chat link: https://v0.app/chat/DqucL0zfWmF